### PR TITLE
Added support for PostgreSQL's UUID data type

### DIFF
--- a/src/main/scala/com/imageworks/migration/ColumnDefinition.scala
+++ b/src/main/scala/com/imageworks/migration/ColumnDefinition.scala
@@ -560,3 +560,9 @@ class DefaultVarcharColumnDefinition
     with ColumnSupportsDefault {
   override protected def sql = optionallyAddLimitToDataType("VARCHAR")
 }
+
+class DefaultUuidColumnDefinition
+    extends ColumnDefinition {
+  override protected def sql = "UUID"
+}
+

--- a/src/main/scala/com/imageworks/migration/DerbyDatabaseAdapter.scala
+++ b/src/main/scala/com/imageworks/migration/DerbyDatabaseAdapter.scala
@@ -115,6 +115,10 @@ class DerbyDatabaseAdapter(override val schemaNameOpt: Option[String])
           "legal data type, you must choose a mapping yourself."
         throw new UnsupportedColumnTypeException(message)
       }
+      case UuidType => {
+        val message = "Derby does not support UUID as a legal data type"
+        throw new UnsupportedColumnTypeException(message)
+      }
       case CharType =>
         new DefaultCharColumnDefinition
       case DecimalType =>

--- a/src/main/scala/com/imageworks/migration/MysqlDatabaseAdapter.scala
+++ b/src/main/scala/com/imageworks/migration/MysqlDatabaseAdapter.scala
@@ -231,6 +231,10 @@ class MysqlDatabaseAdapter(override val schemaNameOpt: Option[String])
         new DefaultVarbinaryColumnDefinition
       case VarcharType =>
         new MysqlVarcharColumnDefinition(characterSetOpt)
+      case UuidType => {
+        val message = "MySQL does not support UUID as a legal data type"
+        throw new UnsupportedColumnTypeException(message)
+      }
     }
   }
 

--- a/src/main/scala/com/imageworks/migration/OracleDatabaseAdapter.scala
+++ b/src/main/scala/com/imageworks/migration/OracleDatabaseAdapter.scala
@@ -204,6 +204,10 @@ class OracleDatabaseAdapter(override val schemaNameOpt: Option[String])
           "choose a mapping your self."
         throw new UnsupportedColumnTypeException(message)
       }
+      case UuidType => {
+        val message = "Oracle does not support UUID as a legal data type"
+        throw new UnsupportedColumnTypeException(message)
+      }
       case CharType =>
         new OracleCharColumnDefinition(useNcharType)
       case DecimalType =>

--- a/src/main/scala/com/imageworks/migration/PostgresqlDatabaseAdapter.scala
+++ b/src/main/scala/com/imageworks/migration/PostgresqlDatabaseAdapter.scala
@@ -112,6 +112,8 @@ class PostgresqlDatabaseAdapter(override val schemaNameOpt: Option[String])
         new PostgresqlByteaColumnDefinition
       case VarcharType =>
         new DefaultVarcharColumnDefinition
+      case UuidType =>
+        new DefaultUuidColumnDefinition
     }
   }
 

--- a/src/main/scala/com/imageworks/migration/SqlType.scala
+++ b/src/main/scala/com/imageworks/migration/SqlType.scala
@@ -48,3 +48,4 @@ case object SmallintType extends SqlType
 case object TimestampType extends SqlType
 case object VarbinaryType extends SqlType
 case object VarcharType extends SqlType
+case object UuidType extends SqlType


### PR DESCRIPTION
Postgres supports a UUID datatype, which has grown fairly popular. I designed it so that other implementations throw an exception (using Derby's lack of BOOLEAN column type as an example).  I tested against 2.9 and 2.10, let me know if you need me to change or add anything.
